### PR TITLE
Plugin-ABC + PassInvocationPlugin

### DIFF
--- a/orges/invoker/pluggable.py
+++ b/orges/invoker/pluggable.py
@@ -169,33 +169,3 @@ class Invocation(object):
 
     def __repr__(self):
         return str(self.fargs)
-
-
-class InvocationPlugin(object):
-    """
-    Base class for invocation plug-ins.
-    """
-
-    def before_invoke(self, invocation):
-        """
-        Gets called when plugpable invoker starts preparing a calls to invoke.
-        """
-        pass
-
-    def on_invoke(self, invocation):
-        """
-        Gets called right before pluggable invoker calls invoke on its invoker.
-        """
-        pass
-
-    def on_result(self, invocation):
-        """
-        Gets called when pluggable invoker receives a callback to on_result.
-        """
-        pass
-
-    def on_error(self, invocation):
-        """
-        Gets called when pluggable invoker receives a callback to on_error.
-        """
-        pass

--- a/orges/plugins/base.py
+++ b/orges/plugins/base.py
@@ -1,0 +1,39 @@
+"""
+"""
+from abc import abstractmethod, ABCMeta
+
+
+class BaseInvocationPlugin(object):
+    """
+    Abstract base class for invocation plug-ins.
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def before_invoke(self, invocation):
+        """
+        Gets called when pluggable invoker starts preparing a calls to invoke.
+        """
+        pass
+
+    @abstractmethod
+    def on_invoke(self, invocation):
+        """
+        Gets called right before pluggable invoker calls invoke on its invoker.
+        """
+        pass
+
+    @abstractmethod
+    def on_result(self, invocation):
+        """
+        Gets called when pluggable invoker receives a callback to on_result.
+        """
+        pass
+
+    @abstractmethod
+    def on_error(self, invocation):
+        """
+        Gets called when pluggable invoker receives a callback to on_error.
+        """
+        pass

--- a/orges/plugins/base.py
+++ b/orges/plugins/base.py
@@ -1,5 +1,3 @@
-"""
-"""
 from abc import abstractmethod, ABCMeta
 
 

--- a/orges/plugins/dummy.py
+++ b/orges/plugins/dummy.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, with_statement
 from orges.plugins.base import BaseInvocationPlugin
 
 
-class PassInvocationPlugin(BaseInvocationPlugin):
+class DummyInvocationPlugin(BaseInvocationPlugin):
     """
     Invocation plug-in that does nothing for all hooks.
     """

--- a/orges/plugins/noop.py
+++ b/orges/plugins/noop.py
@@ -1,0 +1,21 @@
+from __future__ import division, print_function, with_statement
+
+from orges.plugins.base import BaseInvocationPlugin
+
+
+class PassInvocationPlugin(BaseInvocationPlugin):
+    """
+    Invocation plug-in that does nothing for all hooks.
+    """
+
+    def before_invoke(self, invocation):
+        pass
+
+    def on_invoke(self, invocation):
+        pass
+
+    def on_result(self, invocation):
+        pass
+
+    def on_error(self, invocation):
+        pass

--- a/orges/plugins/print.py
+++ b/orges/plugins/print.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function, with_statement
 
-from orges.plugins.noop import PassInvocationPlugin
+from orges.plugins.dummy import DummyInvocationPlugin
 
 
-class PrintInvocationPlugin(PassInvocationPlugin):
+class PrintInvocationPlugin(DummyInvocationPlugin):
     """
     Logs all interaction with the invoker to the standard output.
     """

--- a/orges/plugins/print.py
+++ b/orges/plugins/print.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function, with_statement
 
-from orges.invoker.pluggable import InvocationPlugin
+from orges.plugins.noop import PassInvocationPlugin
 
 
-class PrintInvocationPlugin(InvocationPlugin):
+class PrintInvocationPlugin(PassInvocationPlugin):
     """
     Logs all interaction with the invoker to the standard output.
     """

--- a/orges/plugins/timeout.py
+++ b/orges/plugins/timeout.py
@@ -2,10 +2,10 @@ from __future__ import division, print_function, with_statement
 
 from threading import Timer
 
-from orges.plugins.noop import PassInvocationPlugin
+from orges.plugins.dummy import DummyInvocationPlugin
 
 
-class TimeoutInvocationPlugin(PassInvocationPlugin):
+class TimeoutInvocationPlugin(DummyInvocationPlugin):
     """
     Sets a timeout for each call to invoke.
     """

--- a/orges/plugins/timeout.py
+++ b/orges/plugins/timeout.py
@@ -2,10 +2,10 @@ from __future__ import division, print_function, with_statement
 
 from threading import Timer
 
-from orges.invoker.pluggable import InvocationPlugin
+from orges.plugins.noop import PassInvocationPlugin
 
 
-class TimeoutInvocationPlugin(InvocationPlugin):
+class TimeoutInvocationPlugin(PassInvocationPlugin):
     """
     Sets a timeout for each call to invoke.
     """


### PR DESCRIPTION
Ich hatte gerade die Idee, sowohl eine Plugin-ABC zu haben, als auch eine ein Plugin, das nichts tut (`PassInvocationPlugin`).

Vorteile
- Analogität  
  In jedem Package oberster Ebene befindet sich eine `base.py`.
- Separation of Concerns  
  Die ABC spezifiziert nur das Interface und dokumentiert das zu erwartende Verhalten,  
  das PassInvocationPlugin macht nur nichts und dokumentiert auch nur das.
- Klarheit  
  Es ist offensichtlich, dass die Plugin-ABC nach `plugin/base` hört und  
  das PassInvocationPlugin nach `plugin/pass` gehört.
- Einfachheit  
  Benutzer können das PassIncovationPlugin beerben und dessen `pass`-Verhalten nutzen.

Nachteile
- Komplexität: 28 SLOC mehr.
