### PR TITLE
Renames in args and using modules

### DIFF
--- a/orges/args.py
+++ b/orges/args.py
@@ -152,7 +152,7 @@ class Arg(object):
         yield Arg(self.param, self.param.interval[1])
 
     def __repr__(self):
-        return "%s=%s" % (self.param.display_name, self.value)
+        return "%s=%s" % (self.param.title, self.value)
 
 
 class IntArg(Arg):

--- a/orges/examples/optimizer/gridsearch_saes.py
+++ b/orges/examples/optimizer/gridsearch_saes.py
@@ -8,10 +8,10 @@ from orges.optimizer.gridsearch import GridSearchOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/gridsearch_wind_pred_svr.py
+++ b/orges/examples/optimizer/gridsearch_wind_pred_svr.py
@@ -16,8 +16,8 @@ from orges.optimizer.singleinvoke import SingleInvokeOptimizer
 # https://github.com/cigroup-ol/windml.git
 
 
-@param.int("C_exp", interval=(1, 10), display_name="C_exp")
-@param.int("neg_gamma_exp", interval=(2, 15), display_name="gamma_exp")
+@param.int("C_exp", interval=(1, 10), title="C_exp")
+@param.int("neg_gamma_exp", interval=(2, 15), title="gamma_exp")
 def f(C_exp, neg_gamma_exp):
     gamma_exp = -(neg_gamma_exp)
 

--- a/orges/examples/optimizer/gridsearch_with_global_timeout_saes.py
+++ b/orges/examples/optimizer/gridsearch_with_global_timeout_saes.py
@@ -8,10 +8,10 @@ from orges.optimizer.gridsearch import GridSearchOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/gridsearch_with_local_and_global_timeout_saes.py
+++ b/orges/examples/optimizer/gridsearch_with_local_and_global_timeout_saes.py
@@ -9,10 +9,10 @@ from orges.optimizer.gridsearch import GridSearchOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/gridsearch_with_local_timeout_saes.py
+++ b/orges/examples/optimizer/gridsearch_with_local_timeout_saes.py
@@ -9,10 +9,10 @@ from orges.optimizer.gridsearch import GridSearchOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/rechenberg_saes.py
+++ b/orges/examples/optimizer/rechenberg_saes.py
@@ -8,10 +8,10 @@ from orges.optimizer.rechenberg import RechenbergOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/saes_saes.py
+++ b/orges/examples/optimizer/saes_saes.py
@@ -8,10 +8,10 @@ from orges.optimizer.saes import SAESOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/saes_wind_pred_svr.py
+++ b/orges/examples/optimizer/saes_wind_pred_svr.py
@@ -16,8 +16,8 @@ from orges.optimizer.saes import SAESOptimizer
 # https://github.com/cigroup-ol/windml.git
 
 
-@param.int("C_exp", interval=(1,10), display_name="C_exp")
-@param.int("neg_gamma_exp", interval=(2, 15), display_name="gamma_exp")
+@param.int("C_exp", interval=(1,10), title="C_exp")
+@param.int("neg_gamma_exp", interval=(2, 15), title="gamma_exp")
 def f(C_exp, neg_gamma_exp):
     gamma_exp = -(neg_gamma_exp)
 

--- a/orges/examples/optimizer/saes_with_global_timeout_saes.py
+++ b/orges/examples/optimizer/saes_with_global_timeout_saes.py
@@ -8,10 +8,10 @@ from orges.optimizer.saes import SAESOptimizer
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/saes_with_local_and_global_timeout_saes.py
+++ b/orges/examples/optimizer/saes_with_local_and_global_timeout_saes.py
@@ -9,10 +9,10 @@ from orges.plugins.timeout import TimeoutPlugin
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/examples/optimizer/saes_with_local_timeout_saes.py
+++ b/orges/examples/optimizer/saes_with_local_timeout_saes.py
@@ -9,10 +9,10 @@ from orges.plugins.timeout import TimeoutPlugin
 from orges.examples.algorithm.host.saes import f as saes
 
 
-@param.int("mu", interval=(5, 10), display_name="μ")
-@param.int("lambd", interval=(5, 10), display_name="λ")
-@param.float("tau0", interval=(0, 1), step=0.5, display_name="τ0")
-@param.float("tau1", interval=(0, 1), step=0.5, display_name="τ1")
+@param.int("mu", interval=(5, 10), title="μ")
+@param.int("lambd", interval=(5, 10), title="λ")
+@param.float("tau0", interval=(0, 1), step=0.5, title="τ0")
+@param.float("tau1", interval=(0, 1), step=0.5, title="τ1")
 def f(mu, lambd, tau0, tau1):
     args = dict()
 

--- a/orges/param.py
+++ b/orges/param.py
@@ -6,9 +6,9 @@ using an explicit ParamSpec object. For example::
 
     from orges import param
 
-    @param.int("a", interval=(1, 10), step=2, display_name="α")
-    @param.float("b", interval=(0, 1), display_name"β")
-    @param.bool("g", display_name="γ")
+    @param.int("a", interval=(1, 10), step=2, title="α")
+    @param.float("b", interval=(0, 1), title="β")
+    @param.bool("g", title="γ")
     def some_function(a, b, c):
         pass
 

--- a/orges/paramspec.py
+++ b/orges/paramspec.py
@@ -19,9 +19,9 @@ class ParamSpec(object):
         # The values of "a" should only be multiple of 0.1
         param_spec.float("a", interval=(0, 1), step=0.1)
 
-    The order the parameters are specified matters since they are used to
-    invoke the actual algorithm. That is, given a function ``f(a, b)`` the
-    parameter "a" should be specified before the parameter "b".
+    The order the parameters are specified matters since they are used to invoke
+    the actual algorithm. That is, given a function ``f(a, b)`` the parameter
+    "a" should be specified before the parameter "b".
 
     """
     def __init__(self, via_decorator=False):
@@ -54,39 +54,38 @@ class ParamSpec(object):
             raise DuplicateParamError(param)
         self._params.append(param)
 
-    def float(self, name, interval, display_name=None, step=None):
+    def float(self, name, interval, title=None, step=None):
         """Add a float param to this param_spec object"""
         param = Param(name, "float", interval,
-            step=step, display_name=display_name)
+            step=step, title=title)
 
         self.add_param(param)
 
-    def int(self, name, interval, display_name=None, step=1):
+    def int(self, name, interval, title=None, step=1):
         """Add an int param to this param_spec object"""
         param = IntParam(name, "int", interval,
-            step=step, display_name=display_name)
+            step=step, title=title)
 
         self.add_param(param)
 
-    def bool(self, name, display_name=None):
+    def bool(self, name, title=None):
         """Add a bool param to this param_spec object"""
-        param = BoolParam(name, "bool", (True, False),
-                          display_name=display_name)
+        param = BoolParam(name, "bool", (True, False), title=title)
         self.add_param(param)
 
 
 class Param(object):
     """A specified parameter consisting of a type, an interval and a step."""
 
-    def __init__(self, name, type, interval, step=None, display_name=None):
+    def __init__(self, name, data_type, interval, step=None, title=None):
         self._name = name
-        self._type = type
+        self._data_type = data_type
 
         self._interval = interval
         self.check_interval()
 
         self._step = step
-        self._display_name = display_name or name
+        self._title = title or name
 
     def check_interval(self):
         if self.lower_bound > self.upper_bound:
@@ -98,12 +97,12 @@ class Param(object):
         return self._name
 
     @property
-    def display_name(self):
-        return self._display_name
+    def title(self):
+        return self._title
 
-    @display_name.setter
-    def display_name(self, display_name):
-        self._display_name = display_name
+    @title.setter
+    def title(self, title):
+        self._title = title
 
     @property
     def type(self):
@@ -113,7 +112,7 @@ class Param(object):
         It can be one of the following values: float.
 
         """
-        return self._type
+        return self._data_type
 
     @property
     def interval(self):

--- a/orges/test/unit/test_args.py
+++ b/orges/test/unit/test_args.py
@@ -187,15 +187,15 @@ def test_arg_iter_no_step_raises_error():
     list(Arg(param_spec.params["a"]))
 
 
-def test_arg_repr_no_display_name_shows_name_and_value():
+def test_arg_repr_no_title_shows_name_and_value():
     param_spec = ParamSpec()
     param_spec.int("a", interval=(0, 10))
     eq_(str(Arg(param_spec.params["a"])), "a=0")
 
 
-def test_arg_repr_display_name_shows_display_name_and_value():
+def test_arg_repr_title_shows_title_and_value():
     param_spec = ParamSpec()
-    param_spec.int("a", interval=(0, 10), display_name="α")
+    param_spec.int("a", interval=(0, 10), title="α")
     eq_(str(Arg(param_spec.params["a"])), "α=0")
 
 

--- a/orges/test/unit/test_paramspec.py
+++ b/orges/test/unit/test_paramspec.py
@@ -104,28 +104,28 @@ def test_int_given_no_step_defaults_to_one():
     assert param_spec.params["a"].step == 1
 
 
-def test_given_no_display_name_defaults_to_name():
+def test_given_no_title_defaults_to_name():
     param_spec = ParamSpec()
 
     param_spec.int("a", interval=(1, 10))
     param_spec.float("b", interval=(0, 1))
     param_spec.bool("g")
 
-    assert param_spec.params["a"].display_name == "a"
-    assert param_spec.params["b"].display_name == "b"
-    assert param_spec.params["g"].display_name == "g"
+    assert param_spec.params["a"].title == "a"
+    assert param_spec.params["b"].title == "b"
+    assert param_spec.params["g"].title == "g"
 
 
-def test_given_display_name_saves_it():
+def test_given_title_saves_it():
     param_spec = ParamSpec()
 
-    param_spec.int("a", interval=(1, 10), display_name="α")
-    param_spec.float("b", interval=(0, 1), display_name="β")
-    param_spec.bool("g", display_name="γ")
+    param_spec.int("a", interval=(1, 10), title="α")
+    param_spec.float("b", interval=(0, 1), title="β")
+    param_spec.bool("g", title="γ")
 
-    assert param_spec.params["a"].display_name == "α"
-    assert param_spec.params["b"].display_name == "β"
-    assert param_spec.params["g"].display_name == "γ"
+    assert param_spec.params["a"].title == "α"
+    assert param_spec.params["b"].title == "β"
+    assert param_spec.params["g"].title == "γ"
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
@renke How about renaming `display_name` to `title` to improve brevity and `type` to `data_type` to avoid shadowing the `type()` builtin?
